### PR TITLE
Modules alignment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ default and must be disabled explicitely.
 - **Default:** `color_palette` `kernel` `memory` `os` `shell` `uptime` `user`
 - **Others:** `host`
 
+| Key       | Value                                                           |
+| --------- | --------------------------------------------------------------- |
+| alignment | Alignment of modules relative to art. Can be `top` or `center`. |
+
 #### Module-Specifics
 
 ##### Kernel
@@ -56,12 +60,12 @@ default and must be disabled explicitely.
 
 The following keys can be set in the `[theme]` table.
 
-| Key        | Value                                                                  |
-| ---------- | ---------------------------------------------------------------------- |
-| ascii_art  | (Multiline-) String of ASCII art displayed to the left of modules.     |
-| art_color  | Color of whole ASCII art.                                              |
-| icon_color | Color of module icons.                                                 |
-| info_color | Color of module text.                                                  |
+| Key        | Value                                                              |
+| ---------- | ------------------------------------------------------------------ |
+| ascii_art  | (Multiline-) String of ASCII art displayed to the left of modules. |
+| art_color  | Color of whole ASCII art.                                          |
+| icon_color | Color of module icons.                                             |
+| info_color | Color of module text.                                              |
 
 ### Colors
 
@@ -75,7 +79,7 @@ installed and enabled in your terminal.
 ### Package manager
 
 - **AUR.** `yay -S nerdfetch-rs`
-- **Homebrew.** We have to get a lot more popular to make this possible. Please use *crates.io* in the meantime.
+- **Homebrew.** We have to get a lot more popular to make this possible. Please use _crates.io_ in the meantime.
 - **NIX.** Coming soon.
 - **crates.io.** `cargo install nerdfetch-rs`. Rust toolchain required. (Debian, Red Hat, macOS, etc.)
 - **Build from source.** Clone this repository and run `cargo build --release`. You'll find your binary in the `target/release` directory. Rust toolchain required.

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -8,6 +8,7 @@ pub struct Config {
 
 #[derive(Default, Serialize, Deserialize, Debug)]
 pub struct Modules {
+    pub alignment: Option<Alignment>,
     pub color_palette: Option<ColorPaletteConfig>,
     pub host: Option<HostConfig>,
     pub kernel: Option<KernelConfig>,
@@ -65,6 +66,13 @@ pub struct Theme {
     pub art_color: Option<Color>,
     pub icon_color: Color,
     pub info_color: Color,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum Alignment {
+    Top,
+    Center,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use crate::config::{conf_unwrap_or, schema::Alignment};
+
 mod config;
 mod modules;
 
@@ -17,8 +19,19 @@ fn main() {
         }
     }
 
+    let modules_start = match conf_unwrap_or!(config, Alignment::Top, modules / alignment) {
+        Alignment::Top => 0,
+        Alignment::Center => {
+            if modules.len() < ascii_art.lines().count() {
+                (ascii_art.lines().count() - modules.len()) / 2
+            } else {
+                0
+            }
+        }
+    };
+
     for i in 0..modules.len() {
-        match lines.get_mut(i) {
+        match lines.get_mut(i + modules_start) {
             Some(line) => line.push_str(&format!("  {}", modules.get(i).unwrap())),
             None => lines.push(format!(
                 "    {}{}",


### PR DESCRIPTION
Resolves #8 

## Proposed Changes

  - Added option for modules alignment to config
  - Can be centered or top relative to ASCII art

## Tested on
- [ ] Linux; Distro(s): none
- [X] MacOS
